### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/177/479/421177479.geojson
+++ b/data/421/177/479/421177479.geojson
@@ -656,6 +656,9 @@
     },
     "wof:country":"VN",
     "wof:created":1459009146,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"43ca155e8f02bd4ce4c5124a3d641eb6",
     "wof:hierarchy":[
         {
@@ -667,7 +670,7 @@
         }
     ],
     "wof:id":421177479,
-    "wof:lastmodified":1566651095,
+    "wof:lastmodified":1582380255,
     "wof:name":"Hanoi",
     "wof:parent_id":1108780787,
     "wof:placetype":"locality",

--- a/data/421/179/857/421179857.geojson
+++ b/data/421/179/857/421179857.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"VN",
     "wof:created":1459009236,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5db6c7dc629eab677b4a251705c0cec9",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421179857,
-    "wof:lastmodified":1566651095,
+    "wof:lastmodified":1582380255,
     "wof:name":"H\u00e0 \u00d0\u00f4ng",
     "wof:parent_id":1108781323,
     "wof:placetype":"locality",

--- a/data/421/189/543/421189543.geojson
+++ b/data/421/189/543/421189543.geojson
@@ -190,6 +190,9 @@
     },
     "wof:country":"VN",
     "wof:created":1459009628,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a1cad191d07b5f413c52f4a02d96392c",
     "wof:hierarchy":[
         {
@@ -201,7 +204,7 @@
         }
     ],
     "wof:id":421189543,
-    "wof:lastmodified":1566651089,
+    "wof:lastmodified":1582380254,
     "wof:name":"\u00d0\u00f4ng H\u00e0",
     "wof:parent_id":1108781537,
     "wof:placetype":"locality",

--- a/data/856/327/63/85632763.geojson
+++ b/data/856/327/63/85632763.geojson
@@ -1133,6 +1133,11 @@
     },
     "wof:country":"VN",
     "wof:country_alpha3":"VNM",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6",
+        "meso"
+    ],
     "wof:geomhash":"bfab56491ad2de069103b70b2bd923b9",
     "wof:hierarchy":[
         {
@@ -1147,7 +1152,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648288,
+    "wof:lastmodified":1582380202,
     "wof:name":"Vietnam",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/805/83/85680583.geojson
+++ b/data/856/805/83/85680583.geojson
@@ -311,6 +311,9 @@
         "wk:page":"Qu\u1ea3ng Ninh Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b63f2eb87f596f01860fa5890508673b",
     "wof:hierarchy":[
         {
@@ -326,7 +329,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648269,
+    "wof:lastmodified":1582380192,
     "wof:name":"Qu\u1ea3ng Ninh",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/805/89/85680589.geojson
+++ b/data/856/805/89/85680589.geojson
@@ -304,6 +304,9 @@
         "wk:page":"T\u00e2y Ninh Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6a6a12aa57503ebca5300221a0aa8210",
     "wof:hierarchy":[
         {
@@ -319,7 +322,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648268,
+    "wof:lastmodified":1582380191,
     "wof:name":"T\u00e2y Ninh",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/805/93/85680593.geojson
+++ b/data/856/805/93/85680593.geojson
@@ -310,6 +310,9 @@
         "wd:id":"Q36955"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"78195463c43695d4f15663e52660b332",
     "wof:hierarchy":[
         {
@@ -325,7 +328,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648268,
+    "wof:lastmodified":1582380191,
     "wof:name":"\u0110i\u1ec7n Bi\u00ean",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/805/97/85680597.geojson
+++ b/data/856/805/97/85680597.geojson
@@ -270,6 +270,9 @@
         "wk:page":"B\u1eafc K\u1ea1n Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"93c377cfe5361d7eb38a93e74f17867d",
     "wof:hierarchy":[
         {
@@ -285,7 +288,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648268,
+    "wof:lastmodified":1582380192,
     "wof:name":"\u0110\u00f4ng B\u1eafc",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/806/05/85680605.geojson
+++ b/data/856/806/05/85680605.geojson
@@ -317,6 +317,9 @@
         "wk:page":"Th\u00e1i Nguy\u00ean Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1e3a5cdf1f3f8915b7c4bcd7ca2fd3b1",
     "wof:hierarchy":[
         {
@@ -332,7 +335,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648282,
+    "wof:lastmodified":1582380199,
     "wof:name":"Th\u00e1i Nguy\u00ean",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/806/07/85680607.geojson
+++ b/data/856/806/07/85680607.geojson
@@ -309,6 +309,9 @@
         "wk:page":"Lai Ch\u00e2u Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8e9cea96bede8ee213b225355d6e1069",
     "wof:hierarchy":[
         {
@@ -324,7 +327,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648284,
+    "wof:lastmodified":1582380200,
     "wof:name":"Lai Chau",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/806/11/85680611.geojson
+++ b/data/856/806/11/85680611.geojson
@@ -306,6 +306,9 @@
         "wk:page":"L\u1ea1ng S\u01a1n Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5760c71a90193c31ef224df9afa45446",
     "wof:hierarchy":[
         {
@@ -321,7 +324,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648283,
+    "wof:lastmodified":1582380199,
     "wof:name":"L\u1ea1ng S\u01a1n",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/806/15/85680615.geojson
+++ b/data/856/806/15/85680615.geojson
@@ -305,6 +305,9 @@
         "wk:page":"S\u01a1n La Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c6f8a60d7959fe6478cb17c0a19c5772",
     "wof:hierarchy":[
         {
@@ -320,7 +323,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648286,
+    "wof:lastmodified":1582380200,
     "wof:name":"Son La",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/806/19/85680619.geojson
+++ b/data/856/806/19/85680619.geojson
@@ -304,6 +304,9 @@
         "wk:page":"Thanh H\u00f3a Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"12eca2c6f539c0564899cd42cb34675e",
     "wof:hierarchy":[
         {
@@ -319,7 +322,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648284,
+    "wof:lastmodified":1582380199,
     "wof:name":"Thanh H\u00f3a",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/806/27/85680627.geojson
+++ b/data/856/806/27/85680627.geojson
@@ -304,6 +304,9 @@
         "wk:page":"Tuy\u00ean Quang Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"101391fcba8c44a85550cb3791b327a9",
     "wof:hierarchy":[
         {
@@ -319,7 +322,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648282,
+    "wof:lastmodified":1582380199,
     "wof:name":"Tuy\u00ean Quang",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/806/29/85680629.geojson
+++ b/data/856/806/29/85680629.geojson
@@ -308,6 +308,9 @@
         "wk:page":"Y\u00ean B\u00e1i Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ea4b81fd6e2e6bd0d3148005a7d298bd",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648283,
+    "wof:lastmodified":1582380199,
     "wof:name":"Y\u00ean B\u00e1i",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/806/33/85680633.geojson
+++ b/data/856/806/33/85680633.geojson
@@ -305,6 +305,9 @@
         "wk:page":"H\u00f2a B\u00ecnh Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"22c0f48d338e89cb3fb55683448d2d20",
     "wof:hierarchy":[
         {
@@ -320,7 +323,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648282,
+    "wof:lastmodified":1582380198,
     "wof:name":"H\u00f2a B\u00ecnh",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/806/37/85680637.geojson
+++ b/data/856/806/37/85680637.geojson
@@ -287,6 +287,9 @@
         "wk:page":"H\u1ea3i D\u01b0\u01a1ng Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"34fd5ab721feaab5406b4c1a9ba1a2de",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648285,
+    "wof:lastmodified":1582380200,
     "wof:name":"H\u1ea3i D\u01b0\u01a1ng",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/806/45/85680645.geojson
+++ b/data/856/806/45/85680645.geojson
@@ -356,6 +356,9 @@
         "wd:id":"Q72818"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"66f046626b155f5801afac6a1bc58989",
     "wof:hierarchy":[
         {
@@ -371,7 +374,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648283,
+    "wof:lastmodified":1582380199,
     "wof:name":"H\u1ea3i Ph\u00f2ng",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/806/49/85680649.geojson
+++ b/data/856/806/49/85680649.geojson
@@ -247,6 +247,9 @@
         "wk:page":"H\u01b0ng Y\u00ean Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"77c7be9ec29b1a17c843ac6be01b200e",
     "wof:hierarchy":[
         {
@@ -262,7 +265,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648287,
+    "wof:lastmodified":1582380201,
     "wof:name":"\u0110\u1ed3ng B\u1eb1ng S\u00f4ng H\u1ed3ng",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/806/53/85680653.geojson
+++ b/data/856/806/53/85680653.geojson
@@ -634,6 +634,9 @@
         "wd:id":"Q1858"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a54fd29c967d91dad6c19f1bf2467f18",
     "wof:hierarchy":[
         {
@@ -649,7 +652,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648285,
+    "wof:lastmodified":1582380200,
     "wof:name":"Ha Tay",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/806/59/85680659.geojson
+++ b/data/856/806/59/85680659.geojson
@@ -309,6 +309,9 @@
         "wk:page":"B\u1eafc Ninh Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"68fd0cf826552abd520e631709ab6e0f",
     "wof:hierarchy":[
         {
@@ -324,7 +327,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648281,
+    "wof:lastmodified":1582380198,
     "wof:name":"B\u1eafc Ninh",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/806/63/85680663.geojson
+++ b/data/856/806/63/85680663.geojson
@@ -310,6 +310,9 @@
         "wk:page":"V\u0129nh Ph\u00fac Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1701420f6db3e75f465577c3a12f17ad",
     "wof:hierarchy":[
         {
@@ -325,7 +328,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648286,
+    "wof:lastmodified":1582380200,
     "wof:name":"V\u0129nh Ph\u00fac",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/806/67/85680667.geojson
+++ b/data/856/806/67/85680667.geojson
@@ -307,6 +307,9 @@
         "wk:page":"Ninh B\u00ecnh Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0b1f9e37ac99858f8f6956415f611164",
     "wof:hierarchy":[
         {
@@ -322,7 +325,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648281,
+    "wof:lastmodified":1582380198,
     "wof:name":"Ninh B\u00ecnh",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/806/71/85680671.geojson
+++ b/data/856/806/71/85680671.geojson
@@ -316,6 +316,9 @@
         "wk:page":"H\u00e0 Nam Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"10ea64928c6644378a8964e5b2245bd8",
     "wof:hierarchy":[
         {
@@ -331,7 +334,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648287,
+    "wof:lastmodified":1582380201,
     "wof:name":"H\u00e0 Nam",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/806/77/85680677.geojson
+++ b/data/856/806/77/85680677.geojson
@@ -308,6 +308,9 @@
         "wd:id":"Q36907"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ed2f8c83328ee55feaf63764acef453a",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648286,
+    "wof:lastmodified":1582380200,
     "wof:name":"Nam \u0110\u1ecbnh",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/806/81/85680681.geojson
+++ b/data/856/806/81/85680681.geojson
@@ -308,6 +308,9 @@
         "wk:page":"Ph\u00fa Th\u1ecd Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a5f2a6aba70c047fbc1d9304ed162592",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648284,
+    "wof:lastmodified":1582380199,
     "wof:name":"Ph\u00fa Th\u1ecd",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/806/85/85680685.geojson
+++ b/data/856/806/85/85680685.geojson
@@ -308,6 +308,9 @@
         "wk:page":"B\u1eafc Giang Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4dc0d2fb40e8e128c25c5afd6c08feb2",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648286,
+    "wof:lastmodified":1582380201,
     "wof:name":"B\u1eafc Giang",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/806/89/85680689.geojson
+++ b/data/856/806/89/85680689.geojson
@@ -308,6 +308,9 @@
         "wk:page":"Th\u00e1i B\u00ecnh Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a35ca6903e31ad98a76b316be87534d9",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648283,
+    "wof:lastmodified":1582380199,
     "wof:name":"Th\u00e1i B\u00ecnh",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/806/95/85680695.geojson
+++ b/data/856/806/95/85680695.geojson
@@ -297,6 +297,9 @@
         "wk:page":"H\u00e0 T\u0129nh Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7920a668e82ccb1672da06874c78c688",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648281,
+    "wof:lastmodified":1582380198,
     "wof:name":"Ha Tinh",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/806/99/85680699.geojson
+++ b/data/856/806/99/85680699.geojson
@@ -311,6 +311,9 @@
         "wk:page":"Ngh\u1ec7 An Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0db183a492c2d41a1e318d40b7b21717",
     "wof:hierarchy":[
         {
@@ -326,7 +329,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648285,
+    "wof:lastmodified":1582380200,
     "wof:name":"Ngh\u1ec7 An",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/807/03/85680703.geojson
+++ b/data/856/807/03/85680703.geojson
@@ -513,6 +513,9 @@
         "wk:page":"Qu\u1ea3ng B\u00ecnh Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"816ef2804a04544de938b5ab1cda2e23",
     "wof:hierarchy":[
         {
@@ -528,7 +531,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648270,
+    "wof:lastmodified":1582380194,
     "wof:name":"Qu\u1ea3ng B\u00ecnh",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/807/07/85680707.geojson
+++ b/data/856/807/07/85680707.geojson
@@ -301,6 +301,9 @@
         "wd:id":"Q36690"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d4fb8ed785f07aa39c295884753a0dc6",
     "wof:hierarchy":[
         {
@@ -316,7 +319,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648273,
+    "wof:lastmodified":1582380195,
     "wof:name":"Dak Lak",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/807/13/85680713.geojson
+++ b/data/856/807/13/85680713.geojson
@@ -307,6 +307,9 @@
         "wk:page":"Gia Lai Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2c39d8143ae94cb9e3554a2b409c4e97",
     "wof:hierarchy":[
         {
@@ -322,7 +325,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648276,
+    "wof:lastmodified":1582380196,
     "wof:name":"Gia Lai",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/807/19/85680719.geojson
+++ b/data/856/807/19/85680719.geojson
@@ -310,6 +310,9 @@
         "wk:page":"Kh\u00e1nh H\u00f2a Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1e8a4bc952a03efaf3638a59bc181402",
     "wof:hierarchy":[
         {
@@ -325,7 +328,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648272,
+    "wof:lastmodified":1582380195,
     "wof:name":"Kh\u00e1nh H\u00f2a",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/807/23/85680723.geojson
+++ b/data/856/807/23/85680723.geojson
@@ -298,6 +298,9 @@
         "wd:id":"Q36721"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"52fa219701a42aa778989da41ac07761",
     "wof:hierarchy":[
         {
@@ -313,7 +316,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648275,
+    "wof:lastmodified":1582380196,
     "wof:name":"L\u00e2m \u0110\u1ed3ng",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/807/27/85680727.geojson
+++ b/data/856/807/27/85680727.geojson
@@ -302,6 +302,9 @@
         "wk:page":"Ninh Thu\u1eadn Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"08136cde448d6c45c617f582dc10050d",
     "wof:hierarchy":[
         {
@@ -317,7 +320,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648272,
+    "wof:lastmodified":1582380194,
     "wof:name":"Ninh Thu\u1eadn",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/807/33/85680733.geojson
+++ b/data/856/807/33/85680733.geojson
@@ -307,6 +307,9 @@
         "wk:page":"Ph\u00fa Y\u00ean Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7e5ceddf9fbe458b27a661197ecfb974",
     "wof:hierarchy":[
         {
@@ -322,7 +325,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648271,
+    "wof:lastmodified":1582380194,
     "wof:name":"Ph\u00fa Y\u00ean",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/807/35/85680735.geojson
+++ b/data/856/807/35/85680735.geojson
@@ -300,6 +300,9 @@
         "wd:id":"Q36866"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f472fb8ef2f3f01cce1ad73d0d5530ce",
     "wof:hierarchy":[
         {
@@ -315,7 +318,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648271,
+    "wof:lastmodified":1582380194,
     "wof:name":"B\u00ecnh D\u01b0\u01a1ng",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/807/39/85680739.geojson
+++ b/data/856/807/39/85680739.geojson
@@ -302,6 +302,9 @@
         "wk:page":"Ti\u1ec1n Giang Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2bcd95048b7c58cdd5c660c148118458",
     "wof:hierarchy":[
         {
@@ -317,7 +320,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648274,
+    "wof:lastmodified":1582380196,
     "wof:name":"Ti\u1ec1n Giang",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/807/43/85680743.geojson
+++ b/data/856/807/43/85680743.geojson
@@ -301,6 +301,9 @@
         "wd:id":"Q36723"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"59c2283746154042f2de6321b6427c64",
     "wof:hierarchy":[
         {
@@ -316,7 +319,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648273,
+    "wof:lastmodified":1582380195,
     "wof:name":"\u0110\u1eafk N\u00f4ng",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/807/49/85680749.geojson
+++ b/data/856/807/49/85680749.geojson
@@ -299,6 +299,9 @@
         "wd:id":"Q36672"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c44f3773e0da0dc8053b7a1049e060b3",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648275,
+    "wof:lastmodified":1582380196,
     "wof:name":"B\u00ecnh Ph\u01b0\u1edbc",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/807/53/85680753.geojson
+++ b/data/856/807/53/85680753.geojson
@@ -298,6 +298,9 @@
         "wd:id":"Q36693"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f1e5cf1d29c91c10df6e9c64c4960965",
     "wof:hierarchy":[
         {
@@ -313,7 +316,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648274,
+    "wof:lastmodified":1582380195,
     "wof:name":"B\u00ecnh \u0110\u1ecbnh",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/807/57/85680757.geojson
+++ b/data/856/807/57/85680757.geojson
@@ -295,6 +295,9 @@
         "wk:page":"Kon Tum Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"71caf04f6714a270b33f0b93fbe66d21",
     "wof:hierarchy":[
         {
@@ -310,7 +313,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648270,
+    "wof:lastmodified":1582380194,
     "wof:name":"Kon Tum",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/807/61/85680761.geojson
+++ b/data/856/807/61/85680761.geojson
@@ -304,6 +304,9 @@
         "wk:page":"Qu\u1ea3ng Nam Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"00ffec6c26d950c1856caf33324876ed",
     "wof:hierarchy":[
         {
@@ -319,7 +322,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648270,
+    "wof:lastmodified":1582380193,
     "wof:name":"Qu\u00e0ng Nam",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/807/67/85680767.geojson
+++ b/data/856/807/67/85680767.geojson
@@ -302,6 +302,9 @@
         "wk:page":"Qu\u1ea3ng Ng\u00e3i Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"56ae6f93e8f695ed6c56e95591d25f23",
     "wof:hierarchy":[
         {
@@ -317,7 +320,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648271,
+    "wof:lastmodified":1582380194,
     "wof:name":"Qu\u1ea3ng Ng\u00e3i",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/807/71/85680771.geojson
+++ b/data/856/807/71/85680771.geojson
@@ -315,6 +315,9 @@
         "wk:page":"Qu\u1ea3ng Tr\u1ecb Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"51e79ba29e7cc9a18023748e529e2a7b",
     "wof:hierarchy":[
         {
@@ -330,7 +333,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648275,
+    "wof:lastmodified":1582380196,
     "wof:name":"Qu\u1ea3ng Tr\u1ecb",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/807/75/85680775.geojson
+++ b/data/856/807/75/85680775.geojson
@@ -302,6 +302,9 @@
         "wd:id":"Q36399"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cddcdce83656dc5b32b81a71dccc653b",
     "wof:hierarchy":[
         {
@@ -317,7 +320,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648273,
+    "wof:lastmodified":1582380195,
     "wof:name":"Th\u1eeba Thi\u00ean - Hu\u1ebf",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/807/79/85680779.geojson
+++ b/data/856/807/79/85680779.geojson
@@ -483,6 +483,9 @@
         "wd:id":"Q25282"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"df1cb481ef3b302c06811dbc8f7b0f78",
     "wof:hierarchy":[
         {
@@ -498,7 +501,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648275,
+    "wof:lastmodified":1582380196,
     "wof:name":"\u0110\u00e0 N\u1eb5ng",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/807/81/85680781.geojson
+++ b/data/856/807/81/85680781.geojson
@@ -309,6 +309,9 @@
         "wk:page":"B\u00e0 R\u1ecba-V\u0169ng T\u00e0u Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"91fd18e7e2f69b806073f9a63eb0c390",
     "wof:hierarchy":[
         {
@@ -324,7 +327,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648273,
+    "wof:lastmodified":1582380195,
     "wof:name":"B\u00e0 R\u1ecba - V\u0169ng T\u00e0u",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/807/87/85680787.geojson
+++ b/data/856/807/87/85680787.geojson
@@ -299,6 +299,9 @@
         "wk:page":"B\u00ecnh Thu\u1eadn Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c3dc6ed51a945321b6e89899cdb6ed12",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648272,
+    "wof:lastmodified":1582380194,
     "wof:name":"B\u00ecnh Thu\u1eadn",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/807/91/85680791.geojson
+++ b/data/856/807/91/85680791.geojson
@@ -258,6 +258,9 @@
         "wd:id":"Q33271"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b5856d02e4909bd8b4e345e6584bc661",
     "wof:hierarchy":[
         {
@@ -273,7 +276,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648274,
+    "wof:lastmodified":1582380195,
     "wof:name":"\u0110\u00f4ng Nam B\u1ed9",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/807/97/85680797.geojson
+++ b/data/856/807/97/85680797.geojson
@@ -313,6 +313,9 @@
         "wk:page":"An Giang Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f778062133028e3618b8ac7b81cc46f3",
     "wof:hierarchy":[
         {
@@ -328,7 +331,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648274,
+    "wof:lastmodified":1582380196,
     "wof:name":"An Giang",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/807/99/85680799.geojson
+++ b/data/856/807/99/85680799.geojson
@@ -343,6 +343,9 @@
         "wk:page":"C\u1ea7n Th\u01a1"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4383f3026014afc3662b82e3f891dc1c",
     "wof:hierarchy":[
         {
@@ -358,7 +361,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648274,
+    "wof:lastmodified":1582380196,
     "wof:name":"Can Tho",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/808/07/85680807.geojson
+++ b/data/856/808/07/85680807.geojson
@@ -306,6 +306,9 @@
         "wd:id":"Q36676"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7714e8ca5c6e14bf58bba4bafba27703",
     "wof:hierarchy":[
         {
@@ -321,7 +324,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648278,
+    "wof:lastmodified":1582380197,
     "wof:name":"\u00d0?ng Th\u00e1p",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/808/09/85680809.geojson
+++ b/data/856/808/09/85680809.geojson
@@ -874,6 +874,9 @@
         "wk:page":"Ho Chi Minh City"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"195a73f205fdf104f12c6b37cbb092de",
     "wof:hierarchy":[
         {
@@ -889,7 +892,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648278,
+    "wof:lastmodified":1582380197,
     "wof:name":"H\u1ed3 Ch\u00ed Minh city",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/808/15/85680815.geojson
+++ b/data/856/808/15/85680815.geojson
@@ -314,6 +314,9 @@
         "wk:page":"Ki\u00ean Giang Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c1daf6b742d54350e848123b9517f15d",
     "wof:hierarchy":[
         {
@@ -329,7 +332,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648280,
+    "wof:lastmodified":1582380198,
     "wof:name":"Ki\u00ean Giang",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/808/17/85680817.geojson
+++ b/data/856/808/17/85680817.geojson
@@ -302,6 +302,9 @@
         "wk:page":"Long An Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1c821e693e80de3a463f9272c01c7f81",
     "wof:hierarchy":[
         {
@@ -317,7 +320,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648277,
+    "wof:lastmodified":1582380197,
     "wof:name":"Long An",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/808/25/85680825.geojson
+++ b/data/856/808/25/85680825.geojson
@@ -305,6 +305,9 @@
         "wk:page":"B\u1ebfn Tre Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0082638e4c0e2afb6a736d4fc1cacb18",
     "wof:hierarchy":[
         {
@@ -320,7 +323,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648280,
+    "wof:lastmodified":1582380198,
     "wof:name":"B\u1ebfn Tre",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/808/27/85680827.geojson
+++ b/data/856/808/27/85680827.geojson
@@ -297,6 +297,9 @@
         "wk:page":"H\u1eadu Giang Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"135b4405b25fee57c883c0fe13ad8038",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648277,
+    "wof:lastmodified":1582380197,
     "wof:name":"Hau Giang",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/808/33/85680833.geojson
+++ b/data/856/808/33/85680833.geojson
@@ -305,6 +305,9 @@
         "wk:page":"B\u1ea1c Li\u00eau Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9cfdaffe0df166c26e362edba594110f",
     "wof:hierarchy":[
         {
@@ -320,7 +323,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648277,
+    "wof:lastmodified":1582380197,
     "wof:name":"B\u1ea1c Li\u00eau",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/808/39/85680839.geojson
+++ b/data/856/808/39/85680839.geojson
@@ -316,6 +316,9 @@
         "wk:page":"C\u00e0 Mau Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d766dd6f08b1eb7aad299a2eccf34ef3",
     "wof:hierarchy":[
         {
@@ -331,7 +334,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648279,
+    "wof:lastmodified":1582380197,
     "wof:name":"C\u00e0 Mau",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/808/43/85680843.geojson
+++ b/data/856/808/43/85680843.geojson
@@ -301,6 +301,9 @@
         "wk:page":"S\u00f3c Tr\u0103ng Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"13b68e35f478f49188f20d46ad45b3b8",
     "wof:hierarchy":[
         {
@@ -316,7 +319,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648278,
+    "wof:lastmodified":1582380197,
     "wof:name":"S\u00f3c Tr\u0103ng",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/808/49/85680849.geojson
+++ b/data/856/808/49/85680849.geojson
@@ -310,6 +310,9 @@
         "wk:page":"Tr\u00e0 Vinh Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a6e5ab47a8773a1beebb7938700aedae",
     "wof:hierarchy":[
         {
@@ -325,7 +328,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648280,
+    "wof:lastmodified":1582380198,
     "wof:name":"Tr\u00e0 Vinh",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/808/53/85680853.geojson
+++ b/data/856/808/53/85680853.geojson
@@ -308,6 +308,9 @@
         "wk:page":"V\u0129nh Long Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6b4fb6edcb7ff6f22489090e4deaf797",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648279,
+    "wof:lastmodified":1582380197,
     "wof:name":"V\u0129nh Long",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/808/59/85680859.geojson
+++ b/data/856/808/59/85680859.geojson
@@ -309,6 +309,9 @@
         "wk:page":"Cao B\u1eb1ng Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d9c2da7d0ac150e3d7047e0e66055eca",
     "wof:hierarchy":[
         {
@@ -324,7 +327,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648276,
+    "wof:lastmodified":1582380196,
     "wof:name":"Cao B\u1eb1ng",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/808/63/85680863.geojson
+++ b/data/856/808/63/85680863.geojson
@@ -311,6 +311,9 @@
         "wk:page":"H\u00e0 Giang Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a4ad3e7cf62d9160a2175f451bb5a722",
     "wof:hierarchy":[
         {
@@ -326,7 +329,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648279,
+    "wof:lastmodified":1582380198,
     "wof:name":"H\u00e0 Giang",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/856/808/67/85680867.geojson
+++ b/data/856/808/67/85680867.geojson
@@ -308,6 +308,9 @@
         "wk:page":"L\u00e0o Cai Province"
     },
     "wof:country":"VN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fbcefe7df2224b3817fd17b68a6428dd",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
     "wof:lang_x_spoken":[
         "vie"
     ],
-    "wof:lastmodified":1566648277,
+    "wof:lastmodified":1582380197,
     "wof:name":"L\u00e0o Cai",
     "wof:parent_id":85632763,
     "wof:placetype":"region",

--- a/data/890/423/389/890423389.geojson
+++ b/data/890/423/389/890423389.geojson
@@ -99,6 +99,9 @@
     },
     "wof:country":"VN",
     "wof:created":1469051495,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7f3cc7d60e010cc370e7faa63adedd15",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":890423389,
-    "wof:lastmodified":1566651099,
+    "wof:lastmodified":1582380255,
     "wof:name":"Cam My",
     "wof:parent_id":85680791,
     "wof:placetype":"county",

--- a/data/890/431/499/890431499.geojson
+++ b/data/890/431/499/890431499.geojson
@@ -314,6 +314,9 @@
     },
     "wof:country":"VN",
     "wof:created":1469051894,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0fd31659b055b42666ae64e099a2dfbd",
     "wof:hierarchy":[
         {
@@ -325,7 +328,7 @@
         }
     ],
     "wof:id":890431499,
-    "wof:lastmodified":1566651101,
+    "wof:lastmodified":1582380256,
     "wof:name":"Thanh H\u00f3a",
     "wof:parent_id":1108781387,
     "wof:placetype":"locality",

--- a/data/890/433/759/890433759.geojson
+++ b/data/890/433/759/890433759.geojson
@@ -194,6 +194,9 @@
     },
     "wof:country":"VN",
     "wof:created":1469051993,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f21e011a2b287be2053b52f118b1f9dd",
     "wof:hierarchy":[
         {
@@ -205,7 +208,7 @@
         }
     ],
     "wof:id":890433759,
-    "wof:lastmodified":1566651104,
+    "wof:lastmodified":1582380256,
     "wof:name":"Nam \u00d0\u1ecbnh",
     "wof:parent_id":1108781347,
     "wof:placetype":"locality",

--- a/data/890/435/359/890435359.geojson
+++ b/data/890/435/359/890435359.geojson
@@ -274,6 +274,9 @@
     },
     "wof:country":"VN",
     "wof:created":1469052064,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aae6dc87e89aa9c494b058363cd8f0e5",
     "wof:hierarchy":[
         {
@@ -285,7 +288,7 @@
         }
     ],
     "wof:id":890435359,
-    "wof:lastmodified":1566651104,
+    "wof:lastmodified":1582380256,
     "wof:name":"S\u01a1n La",
     "wof:parent_id":1108780995,
     "wof:placetype":"locality",

--- a/data/890/440/087/890440087.geojson
+++ b/data/890/440/087/890440087.geojson
@@ -286,6 +286,9 @@
     },
     "wof:country":"VN",
     "wof:created":1469052262,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"95118e0c720622f04344fe46fdfe4329",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
         }
     ],
     "wof:id":890440087,
-    "wof:lastmodified":1566651098,
+    "wof:lastmodified":1582380255,
     "wof:name":"Qu\u1ea3ng Ng\u00e3i",
     "wof:parent_id":1108781635,
     "wof:placetype":"locality",

--- a/data/890/443/887/890443887.geojson
+++ b/data/890/443/887/890443887.geojson
@@ -265,6 +265,9 @@
     },
     "wof:country":"VN",
     "wof:created":1469052442,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"97c060e206b23165302521ff25009c2a",
     "wof:hierarchy":[
         {
@@ -276,7 +279,7 @@
         }
     ],
     "wof:id":890443887,
-    "wof:lastmodified":1566651102,
+    "wof:lastmodified":1582380256,
     "wof:name":"Vi\u1ec7t Tr\u00ec",
     "wof:parent_id":1108781165,
     "wof:placetype":"locality",

--- a/data/890/453/121/890453121.geojson
+++ b/data/890/453/121/890453121.geojson
@@ -191,6 +191,9 @@
     },
     "wof:country":"VN",
     "wof:created":1469052841,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e3bf49a49b4c3693e6a459816d12024f",
     "wof:hierarchy":[
         {
@@ -202,7 +205,7 @@
         }
     ],
     "wof:id":890453121,
-    "wof:lastmodified":1566651101,
+    "wof:lastmodified":1582380256,
     "wof:name":"Ninh B\u00ecnh",
     "wof:parent_id":1108781369,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.